### PR TITLE
Update websocket.js

### DIFF
--- a/web/client/websocket.js
+++ b/web/client/websocket.js
@@ -16,7 +16,7 @@ You should have received a copy of the GNU General Public License
 along with Peppy Player. If not, see <http://www.gnu.org/licenses/>.
 */
 
-webSocket = null // global
+webSocket = null; // global
 
 /**
 * Creates new WebSocket channel
@@ -26,26 +26,25 @@ webSocket = null // global
 * @param closeCallback = callback method which will be called when WebSocket channel closed
 */
 function openWebSocket(openCallback, messageCallback, closeCallback) {
-	webSocket = new WebSocket("ws://" + location.host + "/ws");
+    webSocket = new WebSocket(`ws://${location.host}/ws`);
 
-	if(openCallback != null) {
-		webSocket.onopen = openCallback;
-	}
-	if(messageCallback != null) {
-		webSocket.onmessage = messageCallback;
-	}
-	if(closeCallback != null) {
-		webSocket.onclose = closeCallback;
-	}		
+    if (openCallback) {
+        webSocket.onopen = openCallback;
+    }
+    if (messageCallback) {
+        webSocket.onmessage = messageCallback;
+    }
+    if (closeCallback) {
+        webSocket.onclose = closeCallback;
+    }		
 }
 
 /**
 * Closes and nullifies WebSocket object
 */
 function closeWebSocketInClient() {
-	if(webSocket == null) {
-		return;
-	}
-	webSocket.close();
-    webSocket = null;
+    if (webSocket !== null) {
+        webSocket.close();
+        webSocket = null;
+    }
 }


### PR DESCRIPTION
- Normalize indentation to four spaces per level, not mixed tabs and spaces
- Fixed wrong check for supplied arguments, `if (arg != null)` should be `if (arg !== undefined)` or `if (arg)`

Don't get me wrong, the code *worked*, but not as one may think. Consider the following self-executing anonymous function:

```js
(function (arg) {
  console.log(arg, undefined != null, undefined !== null);
})()
```

You'll see the output is:

```js
undefined false true
```

Which means:
- The argument `arg`, for which no value was passed to the function, is `undefined`, not `null`
- `undefined != null` still evaluates to `false` - see https://stackoverflow.com/a/359509/5952681
- For comparison, the `!==` identity operator won't do an implicit type conversion, so `undefined !== null` evaluates to `true`, as expected.

As a shortcut `if (arg)` can be used, though.

Last but not least, as I told you in the German Raspberry Pi forum before, this is an awesome project! 😃